### PR TITLE
Use exact version of dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -11,24 +11,24 @@
   "author": "tmilar",
   "license": "ISC",
   "dependencies": {
-    "bluebird": "^3.5.1",
-    "body-parser": "^1.18.2",
-    "cookie-parser": "^1.4.3",
-    "debug": "^3.1.0",
-    "dotenv": "^5.0.1",
-    "express": "^4.16.2",
-    "google-spreadsheet": "^2.0.4",
-    "hbs": "^4.0.1",
-    "moment": "^2.20.1",
-    "mongoose": "^5.0.6",
-    "morgan": "^1.9.0",
-    "passport": "^0.4.0",
+    "bluebird": "3.5.1",
+    "body-parser": "1.18.2",
+    "cookie-parser": "1.4.3",
+    "debug": "3.1.0",
+    "dotenv": "5.0.1",
+    "express": "4.16.2",
+    "google-spreadsheet": "2.0.4",
+    "hbs": "4.0.1",
+    "moment": "2.20.1",
+    "mongoose": "5.0.6",
+    "morgan": "1.9.0",
+    "passport": "0.4.0",
     "passport-mercadolibre": "0.0.2",
-    "passport-oauth2-refresh": "^1.0.0",
-    "request-promise": "^4.2.2",
-    "serve-favicon": "^2.4.5"
+    "passport-oauth2-refresh": "1.0.0",
+    "request-promise": "4.2.2",
+    "serve-favicon": "2.4.5"
   },
   "devDependencies": {
-    "nodemon": "^1.15.1"
+    "nodemon": "1.15.1"
   }
 }


### PR DESCRIPTION
Creating a .npmrc file with the save exact property and removing ^ from package.json depedencies we achieve a more stable code at the time of being maintained or deployed.