### PR TITLE
dotenv configuration changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,12 @@
+// get env variables
+require('dotenv').config();
+
 const express = require('express');
 const path = require('path');
 const favicon = require('serve-favicon');
 const logger = require('morgan');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
-
-// get env variables
-require('dotenv').config({path: path.resolve(__dirname, ".env")});
 
 // mount db connection
 require("./config/db");

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "body-parser": "^1.18.2",
     "cookie-parser": "^1.4.3",
     "debug": "^3.1.0",
-    "dotenv": "^5.0.1",
     "express": "^4.16.2",
     "google-spreadsheet": "^2.0.4",
     "hbs": "^4.0.1",
@@ -29,6 +28,7 @@
     "serve-favicon": "^2.4.5"
   },
   "devDependencies": {
+    "dotenv": "^5.0.1",
     "nodemon": "^1.15.1"
   }
 }


### PR DESCRIPTION
As it says at [dotenv docs](https://github.com/motdotla/dotenv):
> As early as possible in your application, require and configure dotenv.

So that's why this PR moves the sentence from line number 9 to the number 1 of the `app.js` file
> `config` will read your .env file, parse the contents, assign it to process.env
There is no need of using this line
```js
require('dotenv').config({path: path.resolve(__dirname, ".env")});
```
when you is simpler to use
```js
require('dotenv').config()
```

Also dotenv has been moved to `devDependencies` since is meant to be used in dev - test enviroments and in productions is recommended to use **real** env vars. To still use a .env file in production reject this PR and consider [this one](https://github.com/tmilar/meli-manager/pull/3)