### PR TITLE
Meli client multi paged requests

### DIFF
--- a/lib/meli-client.js
+++ b/lib/meli-client.js
@@ -274,9 +274,12 @@ class MeliClient {
    * @param {Array<Account>} [accounts] - optional accounts select filter
    * @param {string} [status] - filter by question status: one of ['ANSWERED', 'BANNED', 'CLOSED_UNANSWERED', 'DELETED', 'DISABLED', 'UNANSWERED', 'UNDER_REVIEW']
    *
+   * @param {date} [startDate] - filter to retrieve results on or after this date only (inclusive). Optional.
+   * @param {date} [endDate] - filter to retrieve results up to this date only (inclusive). Optional.
+   *
    * @returns {Promise<Array>} questions result, grouped by account
    */
-  async getQuestions({accounts, status} = {}) {
+  async getQuestions({accounts, status, startDate, endDate} = {}) {
     const authenticatedAccounts = await this.filterAccounts(accounts)
 
     const resource = this.resources.GET.questions
@@ -286,8 +289,9 @@ class MeliClient {
       status
     }
 
+    const extraFilters = {startDate, endDate}
 
-    return this.client.multiAccountGet(authenticatedAccounts, {resource, qs})
+    return this.client.multiAccountGet(authenticatedAccounts, {resource, qs, extraFilters})
   }
 
   /**

--- a/lib/meli-client.js
+++ b/lib/meli-client.js
@@ -10,8 +10,11 @@ class Client {
   }
 
   _buildUrl(resource, data) {
-    let resourceUrl = resource
-    if (typeof resource === 'function') {
+    let resourceUrl
+
+    if (typeof resource === 'string') {
+      resourceUrl = resource
+    } else if (typeof resource === 'function') {
       if (!data) {
         throw new Error(`Could not build request url, no data defined for '${resource}' request.`)
       }
@@ -19,6 +22,9 @@ class Client {
       if (!resourceUrl) {
         throw new Error(`Malformed request using data ${JSON.stringify(data)} for 'resource' builder ${resource}.`)
       }
+    } else {
+      // Is object
+      resourceUrl = resource.resource
     }
     return `${this.baseUrl}${resourceUrl}`
   }
@@ -30,7 +36,7 @@ class Client {
     return qs(account)
   }
 
-  _buildRequestOptions({method = 'GET', resource, data, account, qs = {}, body = undefined}) {
+  _buildRequestOptions({method = 'GET', resource, data, qs = {}, body = undefined, account}) {
     return {
       method,
       uri: this._buildUrl(resource, data),
@@ -44,13 +50,42 @@ class Client {
   }
 
   async get({resource, data, qs, account}) {
-    const options = this._buildRequestOptions({resource, data, account, qs})
-    return req(options)
+    const options = this._buildRequestOptions({resource, data, qs, account})
+    const response = await req(options)
+    if (resource.responseMapper) {
+      return resource.responseMapper(response)
+    }
+    return response
   }
 
   async post({resource, data, qs, body, account}) {
-    const options = this._buildRequestOptions({method: 'POST', resource, data, account, qs, body})
+    const options = this._buildRequestOptions({method: 'POST', resource, data, qs, body, account})
     return req(options)
+  }
+
+  async multiPagedGet({resource, data, qs, account}) {
+    const result = await this.get({resource, data, qs, account})
+    const {total, limit} = result
+    if ((total === undefined || limit === undefined) || total <= limit) {
+      return result
+    }
+
+    const pagesRemaining = Math.ceil(total / limit) - 1
+    const self = this
+
+    const resultPages = await Promise.map(new Array(pagesRemaining), (_, page) => {
+      const qsPage = {
+        offset: limit * (page + 1),
+        ...qs
+      }
+      return self.get({resource, data, qs: qsPage, account})
+    })
+
+    resultPages.map(({results}) => results).forEach(pageResults => {
+      result.results.push(...pageResults)
+    })
+
+    return result
   }
 
   async multiAccountGet(accounts, {resource, data, qs}) {
@@ -62,7 +97,7 @@ class Client {
       let response
 
       try {
-        response = await this.get({resource, data, qs, account})
+        response = await this.multiPagedGet({resource, data, qs, account})
       } catch (error) {
         response = error.error || error || {}
         response.message = `Problem with GET '${resource}' request for ${account.nickname}. Msg: ${error.message}`
@@ -79,8 +114,23 @@ class MeliClient {
     this.baseUrl = 'https://api.mercadolibre.com'
     this.resources = {
       GET: {
-        orders: '/orders/search',
-        questions: '/my/received_questions/search',
+        orders: {
+          resource: '/orders/search',
+          responseMapper: response => {
+            const {limit, total} = response.paging
+            response.limit = limit
+            response.total = total
+            return response
+          }
+        },
+        questions: {
+          resource: '/my/received_questions/search',
+          responseMapper: response => {
+            response.results = response.questions
+            delete response.questions
+            return response
+          }
+        },
         question: questionId => `/questions/${questionId}`,
         itemIds: userId => `/users/${userId}/items/search`,
         item: itemId => `/items/${itemId}`,
@@ -216,13 +266,8 @@ class MeliClient {
       status
     }
 
-    const mapQuestionsResponse = ({account, response}) => {
-      response.results = response.questions // Map meli response to match meliClient response structure
-      return {account, response}
-    }
 
-    const response = await this.client.multiAccountGet(authenticatedAccounts, {resource, qs})
-    return response.map(mapQuestionsResponse)
+    return this.client.multiAccountGet(authenticatedAccounts, {resource, qs})
   }
 
   /**

--- a/lib/meli-client.js
+++ b/lib/meli-client.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 const Promise = require('bluebird')
 const req = require('request-promise')
+const moment = require('moment-timezone')
 const Account = require('../model/account')
 const {refresh} = require('../config/meli-auth')
 
@@ -63,10 +64,11 @@ class Client {
     return req(options)
   }
 
-  async multiPagedGet({resource, data, qs, account}) {
+  async multiPagedGet({resource, data, qs, account, extraFilters: {startDate, endDate} = {}}) {
     const result = await this.get({resource, data, qs, account})
     const {total, limit} = result
     if ((total === undefined || limit === undefined) || total <= limit) {
+      // Non-paged resource => just return result
       return result
     }
 
@@ -74,10 +76,16 @@ class Client {
     const self = this
 
     const resultPages = await Promise.map(new Array(pagesRemaining), (_, page) => {
-      const qsPage = {
-        offset: limit * (page + 1),
-        ...qs
+      // Calculate offset for current page, and append to qs
+      const offset = limit * (page + 1)
+      const qsPage = (...params) => {
+        const ret = typeof qs === 'function' ? qs(...params) : qs
+        return {
+          offset,
+          ...ret
+        }
       }
+
       return self.get({resource, data, qs: qsPage, account})
     })
 
@@ -85,10 +93,22 @@ class Client {
       result.results.push(...pageResults)
     })
 
+    // Check extra filters
+    if (!startDate && !endDate) {
+      return result
+    }
+
+    const filteredResults = result.results.filter(({date_created: date}) =>
+      (startDate ? moment(date).toDate() > startDate : true) &&
+      (endDate ? moment(date).toDate() < endDate : true)
+    )
+
+    result.results = filteredResults
+
     return result
   }
 
-  async multiAccountGet(accounts, {resource, data, qs}) {
+  async multiAccountGet(accounts, {resource, data, qs, extraFilters}) {
     if (!accounts || (Array.isArray(accounts) && accounts.length === 0)) {
       throw new Error('Must use at least one account.')
     }
@@ -97,7 +117,7 @@ class Client {
       let response
 
       try {
-        response = await this.multiPagedGet({resource, data, qs, account})
+        response = await this.multiPagedGet({resource, data, qs, account, extraFilters})
       } catch (error) {
         response = error.error || error || {}
         response.message = `Problem with GET '${resource}' request for ${account.nickname}. Msg: ${error.message}`

--- a/lib/meli-client.js
+++ b/lib/meli-client.js
@@ -253,9 +253,12 @@ class MeliClient {
    *
    * @param {Array<Account>} [accounts] - selected accounts
    * @param {number}         [id]       - get only specified order id
+   * @param {date} [startDate] - filter to retrieve results on or after this date only. Optional.
+   * @param {date} [endDate] - filter to retrieve results up to this date only. Optional.
+   *
    * @returns {Promise<Array>} orders response, grouped by account
    */
-  async getOrders({accounts, id} = {}) {
+  async getOrders({startDate, endDate, accounts, id} = {}) {
     const authenticatedAccounts = await this.filterAccounts(accounts)
 
     const resource = this.resources.GET.orders
@@ -264,8 +267,8 @@ class MeliClient {
       sort: 'date_desc',
       q: id
     })
-
-    return this.client.multiAccountGet(authenticatedAccounts, {resource, qs})
+    const extraFilters = {startDate, endDate}
+    return this.client.multiAccountGet(authenticatedAccounts, {resource, qs, extraFilters})
   }
 
   /**

--- a/routes/question.js
+++ b/routes/question.js
@@ -19,9 +19,33 @@ router.post('/answer', async (req, res, next) => {
 
   res.sendStatus(200)
 })
+const _isValidDate = date => Object.prototype.toString.call(date) === '[object Date]'
 
 router.get('/', async (req, res, next) => {
-  const {accounts, store} = req.query
+  const {start, end, accounts, store} = req.query
+
+  // Parse params
+  const dateFormat = 'DD-MM-YY'
+  let startDate
+  let endDate
+
+  if (start) {
+    startDate = moment(start, dateFormat).toDate()
+    if (!_isValidDate(startDate)) {
+      const error = new Error(`Bad request: 'start' date param '${start}' is not properly formatted as '${dateFormat}'`)
+      error.status = 400
+      throw error
+    }
+  }
+
+  if (end) {
+    endDate = moment(end, dateFormat).endOf('day').toDate()
+    if (!_isValidDate(endDate)) {
+      const error = new Error(`Bad request: 'end' date param '${end}' is not properly formatted as '${dateFormat}'`)
+      error.status = 400
+      throw error
+    }
+  }
 
   let accountsArray
   if (accounts) {
@@ -44,7 +68,7 @@ router.get('/', async (req, res, next) => {
     const selectedAccounts = await Account.find(nicknamesFilter)
 
     // 2. fetch remote questions for accounts
-    const meliQuestionFilters = {accounts: selectedAccounts}
+    const meliQuestionFilters = {startDate, endDate, accounts: selectedAccounts}
     questionsResponse = await QuestionService.getQuestions(meliQuestionFilters)
 
     // 3. store selected questions

--- a/service/orders.service.js
+++ b/service/orders.service.js
@@ -67,14 +67,10 @@ class OrdersService {
       .map(ordersResponse => ordersResponse.response.results)
       .reduce((arr = [], order) => arr.concat(order), [])
 
-    // Filter orders between startDate & endDate. Also exclude orders from own accounts.
-    const filteredOrders = orders
-      .filter(order =>
-        (!startDate || (new Date(order.date_closed) >= startDate)) &&
-                (!endDate || (new Date(order.date_closed) <= endDate))
-      ).filter(order => // Not from one of our accounts
-        !accounts.map(a => a.nickname).includes(order.buyer.nickname)
-      )
+    // Exclude orders that are from our own accounts.
+    const filteredOrders = orders.filter(order =>
+      !accounts.map(a => a.nickname).includes(order.buyer.nickname)
+    )
 
     // Sort orders by "date_closed" asc.
     const filteredOrdersSorted = filteredOrders.sort((a, b) => new Date(a.date_closed) - new Date(b.date_closed))

--- a/service/questions.service.js
+++ b/service/questions.service.js
@@ -58,8 +58,8 @@ class QuestionsService {
     return this.meliClient.postQuestionAnswer(answeringAccount, questionId, answerText)
   }
 
-  static async getQuestions({accounts, status}) {
-    return this.meliClient.getQuestions({accounts, status})
+  static async getQuestions({accounts, status, startDate, endDate}) {
+    return this.meliClient.getQuestions({accounts, status, startDate, endDate})
   }
 }
 


### PR DESCRIPTION
This PR will allow to retrieve MeLi API data older than allowed per page request, by requesting all the pages instead.
Also startDate + endDate filters can prevent requesting/retrieving too many results.